### PR TITLE
Add default recovery window option to acts as paranoid

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -141,7 +141,7 @@ module Paranoia
 
   def get_recovery_window_range(opts)
     return opts[:recovery_window_range] if opts[:recovery_window_range]
-    opts[:recovery_window] = default_recovery_window if opts[:recovery_window].blank? && default_recovery_window.present?
+    opts[:recovery_window] = paranoia_default_recovery_window if opts[:recovery_window].blank? && paranoia_default_recovery_window.present?
     return unless opts[:recovery_window]
     (deleted_at - opts[:recovery_window]..deleted_at + opts[:recovery_window])
   end
@@ -256,11 +256,11 @@ ActiveSupport.on_load(:active_record) do
       alias_method :destroy_without_paranoia, :destroy
 
       include Paranoia
-      class_attribute :paranoia_column, :paranoia_sentinel_value
+      class_attribute :paranoia_column, :paranoia_sentinel_value, :paranoia_default_recovery_window
 
       self.paranoia_column = (options[:column] || :deleted_at).to_s
       self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
-      Paranoia.default_recovery_window = options.fetch(:recovery_window) { Paranoia.default_recovery_window }
+      self.paranoia_default_recovery_window = options.fetch(:default_recovery_window) { Paranoia.default_recovery_window }
 
       def self.paranoia_scope
         where(paranoia_column => paranoia_sentinel_value)
@@ -301,6 +301,10 @@ ActiveSupport.on_load(:active_record) do
 
     def paranoia_sentinel_value
       self.class.paranoia_sentinel_value
+    end
+
+    def paranoia_default_recovery_window
+      self.class.paranoia_default_recovery_window
     end
   end
 end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -14,7 +14,7 @@ module Paranoia
   end
 
   def self.default_recovery_window=(val)
-    @@default_recovery_window
+    @@default_recovery_window = val
   end
 
   def self.default_recovery_window

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -141,7 +141,7 @@ module Paranoia
 
   def get_recovery_window_range(opts)
     return opts[:recovery_window_range] if opts[:recovery_window_range]
-    opts[:recovery_window] = paranoia_default_recovery_window if opts[:recovery_window].blank? && paranoia_default_recovery_window.present?
+    opts[:recovery_window] = paranoia_recovery_window if opts[:recovery_window].blank? && paranoia_recovery_window.present?
     return unless opts[:recovery_window]
     (deleted_at - opts[:recovery_window]..deleted_at + opts[:recovery_window])
   end
@@ -256,11 +256,11 @@ ActiveSupport.on_load(:active_record) do
       alias_method :destroy_without_paranoia, :destroy
 
       include Paranoia
-      class_attribute :paranoia_column, :paranoia_sentinel_value, :paranoia_default_recovery_window
+      class_attribute :paranoia_column, :paranoia_sentinel_value, :paranoia_recovery_window
 
       self.paranoia_column = (options[:column] || :deleted_at).to_s
       self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
-      self.paranoia_default_recovery_window = options.fetch(:default_recovery_window) { Paranoia.default_recovery_window }
+      self.paranoia_recovery_window = options.fetch(:recovery_window) { Paranoia.default_recovery_window }
 
       def self.paranoia_scope
         where(paranoia_column => paranoia_sentinel_value)
@@ -303,8 +303,8 @@ ActiveSupport.on_load(:active_record) do
       self.class.paranoia_sentinel_value
     end
 
-    def paranoia_default_recovery_window
-      self.class.paranoia_default_recovery_window
+    def paranoia_recovery_window
+      self.class.paranoia_recovery_window
     end
   end
 end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -261,7 +261,8 @@ ActiveSupport.on_load(:active_record) do
       self.paranoia_column = (options[:column] || :deleted_at).to_s
       self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
       self.paranoia_recovery_window = options.fetch(:recovery_window) { Paranoia.default_recovery_window }
-      binding.pry 
+
+      binding.pry if options.any?
       
       def self.paranoia_scope
         where(paranoia_column => paranoia_sentinel_value)

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -261,7 +261,8 @@ ActiveSupport.on_load(:active_record) do
       self.paranoia_column = (options[:column] || :deleted_at).to_s
       self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
       self.paranoia_recovery_window = options.fetch(:recovery_window) { Paranoia.default_recovery_window }
-
+      binding.pry 
+      
       def self.paranoia_scope
         where(paranoia_column => paranoia_sentinel_value)
       end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -262,8 +262,6 @@ ActiveSupport.on_load(:active_record) do
       self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
       self.paranoia_recovery_window = options.fetch(:recovery_window) { Paranoia.default_recovery_window }
 
-      binding.pry if options.any?
-      
       def self.paranoia_scope
         where(paranoia_column => paranoia_sentinel_value)
       end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -228,6 +228,14 @@ class ParanoiaTest < test_framework
 
   def test_default_sentinel_value
     assert_nil ParanoidModel.paranoia_sentinel_value
+    assert_equal 5, ParanoidModel.paranoia_sentinel_value = 5
+    assert_nil ParanoidModel.paranoia_sentinel_value = nil
+  end
+
+  def default_recovery_window
+    assert_nil ParanoidModel.default_recovery_window
+    assert_equal 120, ParanoidModel.default_recovery_window = 120
+    assert_nil ParanoidModel.default_recovery_window = nil
   end
 
   def test_without_default_scope_option

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -232,7 +232,7 @@ class ParanoiaTest < test_framework
     assert_nil ParanoidModel.paranoia_sentinel_value = nil
   end
 
-  def default_recovery_window
+  def test_default_recovery_window
     assert_nil ParanoidModel.default_recovery_window
     assert_equal 120, ParanoidModel.default_recovery_window = 120
     assert_nil ParanoidModel.default_recovery_window = nil

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -228,14 +228,6 @@ class ParanoiaTest < test_framework
 
   def test_default_sentinel_value
     assert_nil ParanoidModel.paranoia_sentinel_value
-    assert_equal 5, ParanoidModel.paranoia_sentinel_value = 5
-    assert_nil ParanoidModel.paranoia_sentinel_value = nil
-  end
-
-  def test_default_recovery_window
-    assert_nil ParanoidModel.default_recovery_window
-    assert_equal 120, ParanoidModel.default_recovery_window = 120
-    assert_nil ParanoidModel.default_recovery_window = nil
   end
 
   def test_without_default_scope_option

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -230,6 +230,32 @@ class ParanoiaTest < test_framework
     assert_nil ParanoidModel.paranoia_sentinel_value
   end
 
+  def test_default_sentinel_value_setter
+    ParanoidModel.paranoia_sentinel_value = 5
+    assert_equal 5, ParanoidModel.paranoia_sentinel_value
+    ParanoidModel.paranoia_sentinel_value = nil
+  end
+
+  def test_default_sentinel_value
+    assert_nil ParanoidModel.paranoia_sentinel_value
+  end
+
+  def test_default_recovery_window_setter
+    ParanoidModel.paranoia_recovery_window = 5
+    assert_equal 5, ParanoidModel.paranoia_recovery_window
+    ParanoidModel.paranoia_recovery_window = nil
+  end
+
+  def test_default_recovery_window_value
+    assert_nil ParanoidModel.paranoia_recovery_window
+  end
+
+  # def test_default_sentinel_value_setter
+  #   ParanoidModel.paranoia_reovery = 5
+  #   assert_equal 5, ParanoidModel.paranoia_sentinel_value
+  #   ParanoidModel.paranoia_sentinel_value = nil
+  # end  
+
   def test_without_default_scope_option
     model = WithoutDefaultScopeModel.create
     model.destroy

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1175,8 +1175,6 @@ end
 class ParentModelWithRecoveryWindow < ActiveRecord::Base
   acts_as_paranoid(recovery_window: 10.minutes)
 
-  # parent_model_with_recovery_windows
-
   has_many :paranoid_models, foreign_key: 'parent_model_id'
   has_many :related_models, foreign_key: 'parent_model_id'
   has_many :very_related_models, class_name: 'RelatedModel', foreign_key: 'parent_model_id', dependent: :destroy


### PR DESCRIPTION
**Background**
Procure is currently running this version of this gem https://github.com/rubysherpas/paranoia/pull/170 which adds support for a `:dependent_recovery_window` option to be set at the model level with `acts_as_paranoia dependent_recovery_window: 10.minutes` . This pull request was not accepted at the time from the maintainer. However, since then a new maintainer has let a similar PR merge into the main core branch https://github.com/rubysherpas/paranoia/pull/383 pass. However, what we need is the ability to set this a default at the model and application level to preserve existing functionality in the app.

**What the recovery window option does**
When recovering records recursively, associated records will only be restored if they were deleted within the recovery window timespan of the parent's deletion time. This is to enable recovery of a record's associations as they existed at the time it was destroyed.

**What has changed**
[procore/paranoia:core](https://github.com/procore/paranoia) has been synced with [rubysherpas/paranoia:cor](https://github.com/procore/paranoia)e to add Rails 5 support. This branch has been created off of this.

This PR adds that default `:dependent_recovery_window `option. However, to be consistent with the up to date repo this has been renamed simply `:recovery_window`